### PR TITLE
npp-rs-sys improve build rs

### DIFF
--- a/npp-rs-sys/Cargo.toml
+++ b/npp-rs-sys/Cargo.toml
@@ -15,3 +15,6 @@ edition = "2021"
 
 [build-dependencies]
 bindgen = "0.69.1"
+
+[features]
+static-link = []

--- a/npp-rs-sys/build.rs
+++ b/npp-rs-sys/build.rs
@@ -5,13 +5,6 @@ fn find_dir(env_key: &'static str, candidates: Vec<&'static str>) -> Option<Path
     match env::var_os(env_key) {
         Some(val) => Some(PathBuf::from(&val)),
         _ => {
-            for candidate in candidates {
-                let path = PathBuf::from(candidate);
-                if path.exists() {
-                    return Some(path);
-                }
-            }
-
             None
         }
     }
@@ -27,25 +20,25 @@ fn main() {
     println!("cargo:rustc-link-search={}/lib64", cuda_home.to_string_lossy());
 
     let libraries = vec![
-        "cudart_static",
-        "nppc_static",
-        "nppial_static",
-        "nppicc_static",
-        "nppidei_static",
-        "nppif_static",
-        "nppig_static",
-        "nppim_static",
-        "nppist_static",
-        "nppisu_static",
-        "nppitc_static",
-        "npps_static",
+        "cudart",
+        "nppc",
+        "nppial",
+        "nppicc",
+        "nppidei",
+        "nppif",
+        "nppig",
+        "nppim",
+        "nppist",
+        "nppisu",
+        "nppitc",
+        "npps",
     ];
     for library in libraries {
-        println!("cargo:rustc-link-lib=static={}", library);
+        println!("cargo:rustc-link-lib=dylib={}", library);
     }
 
-    println!("cargo:rustc-link-lib=culibos");
-    println!("cargo:rustc-link-lib=dylib=stdc++");
+    //println!("cargo:rustc-link-lib=culibos");
+    //println!("cargo:rustc-link-lib=dylib=stdc++");
 
     println!("cargo:rerun-if-changed=wrapper.h");
 

--- a/npp-rs-sys/build.rs
+++ b/npp-rs-sys/build.rs
@@ -1,47 +1,127 @@
 use std::env;
+use std::os::linux::raw::stat;
 use std::path::PathBuf;
 
-fn find_dir(env_key: &'static str, candidates: Vec<&'static str>) -> Option<PathBuf> {
-    match env::var_os(env_key) {
-        Some(val) => Some(PathBuf::from(&val)),
-        _ => {
-            None
+fn find_dir(cuda_env_vars: &[&'static str], candidates: &[&'static str]) -> Option<PathBuf> {
+    let mut set_variables = std::collections::HashMap::new();
+    let mut set_paths = std::collections::HashSet::new();
+
+    for env_var in cuda_env_vars {
+        if let Some(cand_cuda_path) = env::var_os(env_var) {
+            set_variables.insert(env_var, cand_cuda_path.clone());
+            set_paths.insert(cand_cuda_path);
         }
     }
+
+    match set_paths.len() {
+        0 => {
+            // No paths set, try defaults
+            for candidate in candidates {
+                let p = PathBuf::from(candidate);
+                if p.is_dir() {
+                    println!(
+                        "cargo::warning=Using CUDA path from list of defaults: {}",
+                        p.to_str().unwrap(),
+                    );
+                    return Some(p);
+                }
+            }
+        }
+        1 => {
+            let (env_var, cuda_path) = set_variables.drain().next().unwrap();
+            println!(
+                "cargo::warning=Using CUDA path: {} from environment variable {}",
+                cuda_path.to_str().unwrap(),
+                env_var
+            );
+            return Some(PathBuf::from(cuda_path));
+        }
+        _ => {
+            panic!(
+                "ERROR: npp-rs-sys: Multiple CUDA paths set:
+
+    {:?}
+
+    npp-rs-sys does not know which cuda version should be linked to.",
+                set_variables
+            );
+        }
+    }
+
+    None
+}
+
+fn validate_and_link_npp_install(
+    cuda_home: &PathBuf,
+    npplibs: &[&str],
+    static_link: bool,
+) -> PathBuf {
+    let cuda_include_dir = cuda_home.join("include");
+    let npp_h = cuda_include_dir.join("npp.h");
+    if !npp_h.is_file() {
+        panic!(
+            "ERROR: npp-rs-sys: Could not find npp.h include directory: {}",
+            npp_h.to_string_lossy()
+        );
+    }
+
+    let libdir = cuda_home.join("lib64");
+    if libdir.is_dir() {
+        println!("cargo:rustc-link-search={}", libdir.to_string_lossy());
+    } else {
+        panic!(
+            "ERROR: npp-rs-sys: Could not find CUDA lib directory: {}",
+            libdir.to_string_lossy()
+        );
+    }
+
+    for npplib in npplibs {
+        let libpath = if static_link {
+            libdir.join(format!("lib{}_static.a", npplib))
+        } else {
+            libdir.join(format!("lib{}.so", npplib))
+        };
+        if !libpath.is_file() {
+            panic!(
+                "ERROR: npp-rs-sys: Could not find npp library library: {}",
+                libpath.to_string_lossy()
+            );
+        }
+        if static_link {
+            println!("cargo:rustc-link-lib=static={}_static", npplib);
+        } else {
+            println!("cargo:rustc-link-lib=dylib={}", npplib);
+        }
+    }
+
+    cuda_include_dir
 }
 
 fn main() {
-    let cuda_home = find_dir(
-        "CUDA_HOME",
-        vec!["/opt/cuda", "/usr/local/cuda"],
-    ).expect("Could not find CUDA path");
-    let cuda_include = cuda_home.join("include");
-
-    println!("cargo:rustc-link-search={}/lib64", cuda_home.to_string_lossy());
-
-    let libraries = vec![
-        "cudart",
-        "nppc",
-        "nppial",
-        "nppicc",
-        "nppidei",
-        "nppif",
-        "nppig",
-        "nppim",
-        "nppist",
-        "nppisu",
-        "nppitc",
-        "npps",
+    let cuda_path_vars = ["CUDA_PATH", "CUDA_HOME", "CUDA_ROOT", "CUDA_TOOLKIT_ROOT"];
+    let cuda_default_paths = ["/opt/cuda", "/usr/local/cuda"];
+    let npplibs = vec![
+        "cudart", "nppc", "nppial", "nppicc", "nppidei", "nppif", "nppig", "nppim", "nppist",
+        "nppisu", "nppitc", "npps",
     ];
-    for library in libraries {
-        println!("cargo:rustc-link-lib=dylib={}", library);
+    let static_link = cfg!(feature = "static-link");
+    if static_link {
+        println!("cargo::warning=npp-rs-sys: using static linking",);
+    } else {
+        println!("cargo::warning=npp-rs-sys: using dynamic linking",);
+    }
+    // change detection
+    println!("cargo:rerun-if-changed=wrapper.h");
+    for var in cuda_path_vars {
+        println!("cargo:rerun-if-env-changed={}", var);
     }
 
-    //println!("cargo:rustc-link-lib=culibos");
-    //println!("cargo:rustc-link-lib=dylib=stdc++");
+    let cuda_home =
+        find_dir(&cuda_path_vars, &cuda_default_paths).expect("Could not find CUDA path");
 
-    println!("cargo:rerun-if-changed=wrapper.h");
+    let cuda_include = validate_and_link_npp_install(&cuda_home, &npplibs, static_link);
 
+    // Setup bindgen to scan correct folders
     let bindings = bindgen::Builder::default()
         .clang_arg(format!("-I{}", cuda_include.to_string_lossy()))
         .header("wrapper.h")

--- a/npp-rs-sys/build.rs
+++ b/npp-rs-sys/build.rs
@@ -1,6 +1,5 @@
 use std::env;
-use std::os::linux::raw::stat;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn find_dir(cuda_env_vars: &[&'static str], candidates: &[&'static str]) -> Option<PathBuf> {
     let mut set_variables = std::collections::HashMap::new();
@@ -51,11 +50,7 @@ fn find_dir(cuda_env_vars: &[&'static str], candidates: &[&'static str]) -> Opti
     None
 }
 
-fn validate_and_link_npp_install(
-    cuda_home: &PathBuf,
-    npplibs: &[&str],
-    static_link: bool,
-) -> PathBuf {
+fn validate_and_link_npp_install(cuda_home: &Path, npplibs: &[&str], static_link: bool) -> PathBuf {
     let cuda_include_dir = cuda_home.join("include");
     let npp_h = cuda_include_dir.join("npp.h");
     if !npp_h.is_file() {


### PR DESCRIPTION
 Make build.rs more flexible, and handle errors more gracefully.

* Put static likning behind a feature flag.
* Validate that the directory we are linking to actually contains the
  libraries we need.
* Validate that the npp.h header exists.
* First check ["CUDA_PATH", "CUDA_HOME", "CUDA_ROOT",
  "CUDA_TOOLKIT_ROOT"] if they set a cuda path, if not, look in default
  paths.
* Print nice error messages if anything does not make sense.